### PR TITLE
[어드민] 댓글 관리 페이지 기능 테스트 정의

### DIFF
--- a/src/main/java/com/example/board_admin/dto/ArticleCommentDto.java
+++ b/src/main/java/com/example/board_admin/dto/ArticleCommentDto.java
@@ -1,0 +1,19 @@
+package com.example.board_admin.dto;
+
+import java.time.LocalDateTime;
+
+public record ArticleCommentDto(
+        Long id,
+        Long articleId,
+        UserAccountDto userAccount,
+        Long parentCommentId,
+        String content,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+    public static ArticleCommentDto of(Long id, Long articleId, UserAccountDto userAccount, Long parentCommentId, String content, LocalDateTime createdAt, String createdBy, LocalDateTime modifiedAt, String modifiedBy) {
+        return new ArticleCommentDto(id, articleId, userAccount, parentCommentId, content, createdAt, createdBy, modifiedAt, modifiedBy);
+    }
+}

--- a/src/main/java/com/example/board_admin/dto/response/ArticleCommentClientResponse.java
+++ b/src/main/java/com/example/board_admin/dto/response/ArticleCommentClientResponse.java
@@ -1,0 +1,37 @@
+package com.example.board_admin.dto.response;
+
+import com.example.board_admin.dto.ArticleCommentDto;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record ArticleCommentClientResponse(
+        @JsonProperty("_embedded") Embedded embedded,
+        @JsonProperty("page") Page page
+) {
+
+    public static ArticleCommentClientResponse of() {
+        return new ArticleCommentClientResponse(
+                new ArticleCommentClientResponse.Embedded(List.of()),
+                new ArticleCommentClientResponse.Page(1, 0, 1, 0)
+        );
+    }
+
+    public static ArticleCommentClientResponse of(List<ArticleCommentDto> articleCommentDtos) {
+        return new ArticleCommentClientResponse(
+                new ArticleCommentClientResponse.Embedded(articleCommentDtos),
+                new ArticleCommentClientResponse.Page(articleCommentDtos.size(), articleCommentDtos.size(), 1, 0)
+        );
+    }
+
+    public List<ArticleCommentDto> articleComments() { return this.embedded().articleComments();}
+
+    public record Embedded(List<ArticleCommentDto> articleComments){}
+
+    public record Page(
+            int size,
+            long totalElements,
+            int totalPage,
+            int number
+    ) { }
+}

--- a/src/main/java/com/example/board_admin/service/ArticleCommentManagementService.java
+++ b/src/main/java/com/example/board_admin/service/ArticleCommentManagementService.java
@@ -1,0 +1,24 @@
+package com.example.board_admin.service;
+
+import com.example.board_admin.dto.ArticleCommentDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class ArticleCommentManagementService {
+
+    public List<ArticleCommentDto> getArticleComments() {
+        return List.of();
+    }
+
+    public ArticleCommentDto getArticleComment(Long articleCommentId) {
+        return null;
+    }
+
+    public void deleteArticleComment(Long articleCommentId) {
+
+    }
+}

--- a/src/test/java/com/example/board_admin/controller/ArticleCommentManagementControllerTest.java
+++ b/src/test/java/com/example/board_admin/controller/ArticleCommentManagementControllerTest.java
@@ -1,22 +1,37 @@
 package com.example.board_admin.controller;
 
 import com.example.board_admin.config.SecurityConfig;
+import com.example.board_admin.domain.constant.RoleType;
+import com.example.board_admin.dto.ArticleCommentDto;
+import com.example.board_admin.dto.ArticleDto;
+import com.example.board_admin.dto.UserAccountDto;
+import com.example.board_admin.service.ArticleCommentManagementService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@DisplayName("View 컨트롤러 - 댓글 관리")
+@DisplayName("컨트롤러 - 댓글 관리")
 @Import(SecurityConfig.class)
 @WebMvcTest(ArticleCommentManagementController.class)
 class ArticleCommentManagementControllerTest {
     private final MockMvc mvc;
+    @MockBean private ArticleCommentManagementService articleCommentManagementService;
 
     public ArticleCommentManagementControllerTest(@Autowired MockMvc mvc) {
         this.mvc = mvc;
@@ -26,11 +41,74 @@ class ArticleCommentManagementControllerTest {
     @Test
     void givenNothing_whenRequestingArticleCommentsManagementView_thenReturnsArticleCommentsManagementView() throws Exception {
         //given
+        given(articleCommentManagementService.getArticleComments()).willReturn(List.of());
 
         //when && then
         mvc.perform(get("/management/article-comments"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(view().name("management/article-comments"));
+                .andExpect(view().name("management/article-comments"))
+                .andExpect(model().attribute("comments", List.of()));
+        then(articleCommentManagementService).should().getArticleComments();
+    }
+
+    @DisplayName("[Data][Get] 댓글 1개 - 정상 호출")
+    @Test
+    void givenArticleCommentId_whenRequestingArticleComment_thenReturnsArticleComment() throws Exception {
+        //given
+        Long articleCommentId = 1L;
+        ArticleCommentDto articleCommentDto = createArticleCommentDto("content");
+        given(articleCommentManagementService.getArticleComment(articleCommentId)).willReturn(articleCommentDto);
+
+        //when && then
+        mvc.perform(get("/management/article-comments/" + articleCommentId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").value(articleCommentId))
+                .andExpect(jsonPath("$.content").value(articleCommentDto.content()))
+                .andExpect(jsonPath("$.userAccount.nickname").value(articleCommentDto.userAccount().nickname()));
+        then(articleCommentManagementService).should().getArticleComment(articleCommentId);
+    }
+
+    @DisplayName("[View][Post] 댓글 삭제 - 정상 호출")
+    @Test
+    void givenArticleCommentId_whenRequestingDeletion_thenRedirectsToArticleCommentManagementView() throws Exception {
+        //given
+        Long articleCommentId = 1L;
+        willDoNothing().given(articleCommentManagementService).deleteArticleComment(articleCommentId);
+
+        //when && then
+        mvc.perform(post("/management/article-comments/" + articleCommentId)
+                        .with(csrf())
+                )
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/management/article-comments"))
+                .andExpect(redirectedUrl("/management/article-comments"));
+        then(articleCommentManagementService).should().deleteArticleComment(articleCommentId);
+    }
+
+    private ArticleCommentDto createArticleCommentDto(String content) {
+        return ArticleCommentDto.of(
+                1L,
+                1L,
+                createUserAccountDto(),
+                null,
+                content,
+                LocalDateTime.now(),
+                "uno",
+                LocalDateTime.now(),
+                "uno"
+        );
+    }
+
+    private UserAccountDto createUserAccountDto() {
+        return UserAccountDto.of(
+                "testId",
+                "testPw",
+                Set.of(RoleType.ADMIN),
+                "test@email",
+                "testNickname",
+                "testMemo"
+        );
     }
 }

--- a/src/test/java/com/example/board_admin/controller/ArticleManagementControllerTest.java
+++ b/src/test/java/com/example/board_admin/controller/ArticleManagementControllerTest.java
@@ -5,7 +5,6 @@ import com.example.board_admin.domain.constant.RoleType;
 import com.example.board_admin.dto.ArticleDto;
 import com.example.board_admin.dto.UserAccountDto;
 import com.example.board_admin.service.ArticleManagementService;
-import com.jayway.jsonpath.JsonPath;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,7 +12,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;

--- a/src/test/java/com/example/board_admin/service/ArticleCommentManagementServiceTest.java
+++ b/src/test/java/com/example/board_admin/service/ArticleCommentManagementServiceTest.java
@@ -1,0 +1,175 @@
+package com.example.board_admin.service;
+
+import com.example.board_admin.domain.constant.RoleType;
+import com.example.board_admin.dto.ArticleCommentDto;
+import com.example.board_admin.dto.UserAccountDto;
+import com.example.board_admin.dto.properties.ProjectProperties;
+import com.example.board_admin.dto.response.ArticleCommentClientResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.autoconfigure.web.client.AutoConfigureWebClient;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@ActiveProfiles("test")
+@DisplayName("비지니스 로직 - 댓글 관리")
+class ArticleCommentManagementServiceTest {
+
+//    @Disabled("실제 API 호출 결과 관찰용이므로 평상시엔 비활성화")
+    @DisplayName("실제 API 호출 테스트")
+    @SpringBootTest
+    @Nested
+    class RealApiTest {
+        private final ArticleCommentManagementService sut;
+
+        @Autowired
+        public RealApiTest(ArticleCommentManagementService sut) {
+            this.sut = sut;
+        }
+
+        @DisplayName("댓글 API를 호출하면, 댓글들을 가져온다.")
+        @Test
+        void givenNothing_whenCallingArticleCommentsApi_thenReturnsArticleCommentList(){
+            //given
+
+            //when
+            List<ArticleCommentDto> articleComments = sut.getArticleComments();
+            //then
+            System.out.println(articleComments.stream().findFirst());
+            assertThat(articleComments).isNotNull();
+        }
+    }
+
+    @DisplayName("API Mocking 테스트")
+    @EnableConfigurationProperties(ProjectProperties.class)
+    @AutoConfigureWebClient(registerRestTemplate = true)
+    @RestClientTest(ArticleCommentManagementService.class)
+    @Nested
+    class RestTemplateTest {
+
+        private final ArticleCommentManagementService sut;
+
+        private final ProjectProperties projectProperties;
+        private final MockRestServiceServer server;
+        private final ObjectMapper mapper;
+
+        @Autowired
+        public RestTemplateTest(
+                ArticleCommentManagementService sut,
+                ProjectProperties projectProperties,
+                MockRestServiceServer server,
+                ObjectMapper mapper) {
+
+            this.sut = sut;
+            this.projectProperties = projectProperties;
+            this.server = server;
+            this.mapper = mapper;
+        }
+
+        @DisplayName("댓글 API를 호출하면, 댓글들을 가져온다.")
+        @Test
+        void givenNothing_whenCallingArticleCommentsApi_thenReturnsArticleCommentList() throws Exception {
+            //given
+            ArticleCommentDto expectedArticle = createArticleCommentDto("글");
+            ArticleCommentClientResponse expectedResponse = ArticleCommentClientResponse.of(List.of(expectedArticle));
+
+            server.expect(requestTo(projectProperties.board().url() + "/api/articleComments?size=10000"))
+                    .andRespond(withSuccess(
+                            mapper.writeValueAsString(expectedResponse),
+                            MediaType.APPLICATION_JSON
+                    ));
+
+            //when
+            List<ArticleCommentDto> result = sut.getArticleComments();
+
+            //then
+            assertThat(result).first()
+                    .hasFieldOrPropertyWithValue("id", expectedArticle.id())
+                    .hasFieldOrPropertyWithValue("content", expectedArticle.content())
+                    .hasFieldOrPropertyWithValue("userAccount.nickname", expectedArticle.userAccount().nickname());
+            server.verify();
+        }
+
+        @DisplayName("댓글을 ID와 함께 API 조회하면, 댓글을 가져온다.")
+        @Test
+        void givenArticleCommentId_whenCallingArticleCommentApi_thenReturnsArticleComment() throws Exception{
+            //given
+            Long articleCommentId = 1L;
+            ArticleCommentDto expectedArticleComment = createArticleCommentDto("글");
+            server.expect(requestTo(projectProperties.board().url() + "/api/articleComments/" + articleCommentId))
+                    .andRespond(withSuccess(
+                            mapper.writeValueAsString(expectedArticleComment),
+                            MediaType.APPLICATION_JSON
+                    ));
+
+            //when
+            ArticleCommentDto result = sut.getArticleComment(articleCommentId);
+
+            //then
+            assertThat(result)
+                    .hasFieldOrPropertyWithValue("id", expectedArticleComment.id())
+                    .hasFieldOrPropertyWithValue("content", expectedArticleComment.content())
+                    .hasFieldOrPropertyWithValue("userAccount.nickname", expectedArticleComment.userAccount().nickname());
+            server.verify();
+        }
+
+        @DisplayName("댓글을 ID와 함께 댓글 삭제 API를 호출하면, 댓글을 삭제한다.")
+        @Test
+        void givenArticleCommentId_whenCallingDeleteArticleCommentApi_thenDeletesArticleComment() throws Exception{
+            //given
+            Long articleCommentId = 1L;
+            ArticleCommentDto expectedArticle = createArticleCommentDto("글");
+            server.expect(requestTo(projectProperties.board().url() + "/api/articleComments/" + articleCommentId))
+                    .andExpect(method(HttpMethod.DELETE))
+                    .andRespond(withSuccess());
+
+            //when
+            sut.deleteArticleComment(articleCommentId);
+
+            //then
+            server.verify();
+        }
+
+        private ArticleCommentDto createArticleCommentDto(String content) {
+            return ArticleCommentDto.of(
+                    1L,
+                    1L,
+                    createUserAccountDto(),
+                    null,
+                    content,
+                    LocalDateTime.now(),
+                    "uno",
+                    LocalDateTime.now(),
+                    "uno"
+            );
+        }
+
+        private UserAccountDto createUserAccountDto() {
+            return UserAccountDto.of(
+                    "testId",
+                    "testPw",
+                    Set.of(RoleType.ADMIN),
+                    "test@email",
+                    "testNickname",
+                    "testMemo"
+            );
+        }
+    }
+}

--- a/src/test/java/com/example/board_admin/service/ArticleManagementServiceTest.java
+++ b/src/test/java/com/example/board_admin/service/ArticleManagementServiceTest.java
@@ -46,7 +46,7 @@ class ArticleManagementServiceTest {
         
         @DisplayName("게시글 API를 호출하면, 게시글을 가져온다.")
         @Test
-        void given_when_then(){
+        void givenNothing_whenCallingArticlesApi_thenReturnsArticleList(){
             //given
 
             //when


### PR DESCRIPTION
이 pr은 댓글 관리 페이지 기능을 구현하기 위한 비즈니스 로직과 컨트롤러의 테스트를 추가한다.
구현이 없으므로 테스트가 실패하는 상태.

This closes #12 